### PR TITLE
Update community.py

### DIFF
--- a/pymino/ext/community.py
+++ b/pymino/ext/community.py
@@ -5979,24 +5979,24 @@ class Community:
         if viewOnly is not None:
             responses.append(ApiResponse(self.session.handler(
                 method = "POST",
-                url = f"/x{self.community_id or comId}/s/chat/thread/{chatId}/view-only/{'enable' if viewOnly else 'disable'}"
+                url = f"/x{self.community_id if comId is None else comId}/s/chat/thread/{chatId}/view-only/{'enable' if viewOnly else 'disable'}"
             )).status_code)
         
         if canInvite is not None:
             responses.append(ApiResponse(self.session.handler(
                 method = "POST",
-                url = f"/x{self.community_id or comId}/s/chat/thread/{chatId}/members-can-invite/{'enable' if canInvite else 'disable'}"
+                url = f"/x{self.community_id if comId is None else comId}/s/chat/thread/{chatId}/members-can-invite/{'enable' if canInvite else 'disable'}"
             )).status_code)
         
         if canTip is not None:
             responses.append(ApiResponse(self.session.handler(
                 method = "POST",
-                url = f"/x{self.community_id or comId}/s/chat/thread/{chatId}/tipping-perm-status/{'enable' if canTip else 'disable'}"
+                url = f"/x{self.community_id if comId is None else comId}/s/chat/thread/{chatId}/tipping-perm-status/{'enable' if canTip else 'disable'}"
             )).status_code)
         
         responses.append(ApiResponse(self.session.handler(
             method = "POST",
-            url = f"/x{self.community_id or comId}/s/chat/thread/{chatId}",
+            url = f"/x{self.community_id if comId is None else comId}/s/chat/thread/{chatId}",
             data = data
         )).status_code)
 


### PR DESCRIPTION
Apenas um pequeno ajuste.

Eu estava tentando editar um  chat público usando `bot.community.edit_chat(chatId=chatId, title=title, comId=comId)`, mas eu sempre recebia um erro dizendo que os dados não existiam, isso porque a função usa apenas o community_id que está definido no bot.  Agora dessa forma o bot consegue editar chats independente da comunidade definida nele.